### PR TITLE
Hotfix/image uploads cdn assets

### DIFF
--- a/adminlteui/templates/admin/base.html
+++ b/adminlteui/templates/admin/base.html
@@ -12,10 +12,10 @@
     <!-- Tell the browser to be responsive to screen width -->
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     <!-- Bootstrap 3.3.6 -->
-    <link rel="stylesheet" href={% static "admin/bootstrap/css/bootstrap.min.css" %}>
+    <link rel="stylesheet" href="//stackpath.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
     <!-- Font Awesome -->
     <!--<link rel="stylesheet" href="//cdn.bootcss.com/font-awesome/4.5.0/css/font-awesome.min.css">-->
-    <link rel="stylesheet" href={% static "admin/font-awesome/css/font-awesome.min.css" %}>
+    <link rel="stylesheet" href="//stackpath.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <!-- Ionicons -->
     <link rel="stylesheet" href={% static "admin/ionicons/ionicons.min.css" %}>
 

--- a/adminlteui/templates/admin/base.html
+++ b/adminlteui/templates/admin/base.html
@@ -34,8 +34,8 @@
 
     <link rel="stylesheet" href={% static "admin/dist/css/django.css" %}>
     {% if adminlte_site_logo.valid %}
-    <link rel="apple-touch-icon" href="/{{ adminlte_site_logo.site_logo }}">
-    <link rel="icon" href="/{{ adminlte_site_logo.site_logo }}">
+    <link rel="apple-touch-icon" href="{{ adminlte_site_logo.site_logo }}">
+    <link rel="icon" href="{{ adminlte_site_logo.site_logo }}">
     {% else %}
     <link rel="apple-touch-icon" href="{% static "admin/dist/img/default-log.svg" %}">
     <link rel="icon" href="{% static "admin/dist/img/default-log.svg" %}">
@@ -58,7 +58,7 @@
             <!-- mini logo for sidebar mini 50x50 pixels -->
             <span class="logo-mini">
                 {% if adminlte_site_logo.valid %}
-                <img src="/{{ adminlte_site_logo.site_logo }}" class="user-image" alt="User Image" style="width:45px;height:45px;padding:5px;">
+                <img src="{{ adminlte_site_logo.site_logo }}" class="user-image" alt="User Image" style="width:45px;height:45px;padding:5px;">
                 {% else %}
                 <img src={% static "admin/dist/img/default-log.svg" %} class="user-image" alt="User Image" style="width:45px;height:45px;padding:5px;">
                 {% endif %}
@@ -66,7 +66,7 @@
             <!-- logo for regular state and mobile devices -->
             <span class="logo-lg">
                 {% if adminlte_site_logo.valid %}
-                <img src="/{{ adminlte_site_logo.site_logo }}" class="user-image" alt="User Image" style="width:45px;height:45px;padding:5px;">
+                <img src="{{ adminlte_site_logo.site_logo }}" class="user-image" alt="User Image" style="width:45px;height:45px;padding:5px;">
                 {% else %}
                 <img src={% static "admin/dist/img/default-log.svg" %} class="user-image" alt="User Image" style="width:45px;height:45px;padding:5px;">
                 {% endif %}

--- a/adminlteui/templates/admin/login.html
+++ b/adminlteui/templates/admin/login.html
@@ -17,7 +17,7 @@
     <!-- Tell the browser to be responsive to screen width -->
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     <!-- Bootstrap 3.3.6 -->
-    <link rel="stylesheet" href={% static "admin/bootstrap/css/bootstrap.min.css" %}>
+    <link rel="stylesheet" href="//stackpath.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="//cdn.bootcss.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <!-- Ionicons -->

--- a/adminlteui/templates/registration/logged_out.html
+++ b/adminlteui/templates/registration/logged_out.html
@@ -17,7 +17,7 @@
     <!-- Tell the browser to be responsive to screen width -->
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     <!-- Bootstrap 3.3.6 -->
-    <link rel="stylesheet" href={% static "admin/bootstrap/css/bootstrap.min.css" %}>
+    <link rel="stylesheet" href="//stackpath.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="//cdn.bootcss.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <!-- Ionicons -->


### PR DESCRIPTION
- Use a CDN for serving static assets (S3 backend doesnt serve fonts very well)
- Make logo upload storage engine agnostic by using `default_storage`

Fixes https://github.com/wuyue92tree/django-adminlte-ui/issues/18